### PR TITLE
Fix internal error in apps with plugins

### DIFF
--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -339,7 +339,7 @@ class AppManager(object):
 
         try:
             is_main_app = self._current_app is None
-            has_plugin = False
+            has_plugin = not not app.plugins
 
             rospy.loginfo('App: {} main: {} plugins: {}'.format(appname, is_main_app, has_plugin))
             if is_main_app:
@@ -413,7 +413,6 @@ class AppManager(object):
                             .format(app_plugin_type))
 
             #TODO:XXX This is a roslaunch-caller-like abomination.  Should leverage a true roslaunch API when it exists.
-            has_plugin = len(plugin_launch_files) > 0
             if app.launch:
                 try:
                     self._launch = roslaunch.parent.ROSLaunchParent(

--- a/src/app_manager/app_manager.py
+++ b/src/app_manager/app_manager.py
@@ -728,6 +728,7 @@ class AppManager(object):
                 resp.message = "app %s is not running"%(appname)                    
             else:
                 try:
+                    app_status_message = None
                     if self._launch or self._current_process:
                         rosinfo_message = "handle stop app: stopping app [%s]"%(appname)
                         app_status_message = 'stopping %s'%(app.display_name)
@@ -740,12 +741,14 @@ class AppManager(object):
                             app_status_message += "by timeout"
                             resp.message += " by timeout"
                         rospy.loginfo(rosinfo_message)
-                        self._status_pub.publish(AppStatus(AppStatus.INFO, app_status_message))
                     else:
                         rospy.loginfo("handle stop app: app [%s] is not running"%(appname))
                         resp.message = "app [%s] is not running"%(appname)
                         resp.error_code = StatusCodes.NOT_RUNNING
                 finally:
+                    if app_status_message is not None:
+                        self._status_pub.publish(
+                            AppStatus(AppStatus.INFO, app_status_message))
                     self._launch = None
                     self._current_process = None
                     self._set_current_app(None, None)


### PR DESCRIPTION
Plugins with no launch file are currently failing due to e7aea365df9e47b823deb968613df3094685ec6c (my bad...)

```
[ERROR] [1664608906.771791] [/app_manager:rosout]: handle stop app: internal error [app_manager.py, line 740: 'NoneType' object does not support item assignment]
```

Example .app file:
```yaml
display: Hello World
platform: test
launch: test_pkg/hello_world.launch
interface: test_pkg/hello_world.interface
icon: test_pkg/hello_world.png

plugins:
  - name: topic_publisher
    type: app_publisher/rostopic_publisher_plugin
    plugin_args:
      start_topics:
        - name: /chatter
          pkg: std_msgs
          type: String
          field:
            data: "Start!"
```

This is because the `has_plugins` was being judged based on the `plugin_launch_files`, but many plugins have no launch (only module).

This error was also preventing updating the `app_status` topic, so I added this as well.